### PR TITLE
fix: use watch instead of watch-project

### DIFF
--- a/src/watch.ts
+++ b/src/watch.ts
@@ -21,7 +21,7 @@ export const watch = (configurationInput: ConfigurationInput) => {
   const client = new Client();
 
   return new Promise((resolve, reject) => {
-    client.command(['watch-project', project], (error, response) => {
+    client.command(['watch', project], (error, response) => {
       if (error) {
         log.error(
           {


### PR DESCRIPTION
Even though `watch` is deprecated, it works as expected. `watch-project` ends up watching the entire CWD because, according to the docs, it looks for a `. watchmanconfig` to establish the root.