### PR TITLE
✏️ Add Trigger Name Prefix and Customizable Hex Color to Logs for Enhanced Clarity and Consistency

### DIFF
--- a/src/createSpawn.ts
+++ b/src/createSpawn.ts
@@ -30,11 +30,13 @@ export const createSpawn = (
     cwd = process.cwd(),
     abortSignal,
     throttleOutput,
-    triggerName
+    triggerName,
+    triggerHexColor,
   }: {
     abortSignal?: AbortSignal;
     cwd?: string;
     throttleOutput?: Throttle;
+    triggerHexColor?: string;
     triggerName?: string;
   } = {},
 ) => {
@@ -66,7 +68,9 @@ export const createSpawn = (
     },
   );
 
-  const colorText = chalk.hex(randomColor({ luminosity: 'dark' }));
+  const colorText = chalk.hex(
+    triggerHexColor || randomColor({ luminosity: 'dark' }),
+  );
 
   return async (pieces: TemplateStringsArray, ...args: any[]) => {
     const binPath = (await findNearestDirectory('node_modules', cwd)) + '/.bin';
@@ -81,7 +85,10 @@ export const createSpawn = (
     const formatChunk = (chunk: Buffer) => {
       const prefixTriggerName = triggerName ? triggerName + ' ' : '';
 
-      return prefixLines(chunk.toString().trimEnd(), colorText(`${prefixTriggerName}${taskId}`) + ' > ');
+      return prefixLines(
+        chunk.toString().trimEnd(),
+        colorText(`${prefixTriggerName}${taskId}`) + ' > ',
+      );
     };
 
     if (throttleOutput?.delay) {

--- a/src/createSpawn.ts
+++ b/src/createSpawn.ts
@@ -30,10 +30,12 @@ export const createSpawn = (
     cwd = process.cwd(),
     abortSignal,
     throttleOutput,
+    triggerName
   }: {
     abortSignal?: AbortSignal;
     cwd?: string;
     throttleOutput?: Throttle;
+    triggerName?: string;
   } = {},
 ) => {
   let stdoutBuffer: string[] = [];
@@ -77,7 +79,9 @@ export const createSpawn = (
     let onStderr: (chunk: Buffer) => void;
 
     const formatChunk = (chunk: Buffer) => {
-      return prefixLines(chunk.toString().trimEnd(), colorText(taskId) + ' > ');
+      const prefixTriggerName = triggerName ? triggerName + ' ' : '';
+
+      return prefixLines(chunk.toString().trimEnd(), colorText(`${prefixTriggerName}${taskId}`) + ' > ');
     };
 
     if (throttleOutput?.delay) {

--- a/src/subscribe.ts
+++ b/src/subscribe.ts
@@ -107,6 +107,7 @@ const runTask = async ({
           abortSignal: abortController?.signal,
           cwd: trigger.cwd,
           throttleOutput: trigger.throttleOutput,
+          triggerName: trigger.name,
         }),
         taskId,
       });
@@ -355,6 +356,7 @@ export const subscribe = (trigger: Trigger): Subscription => {
           await trigger.onTeardown({
             spawn: createSpawn(taskId, {
               throttleOutput: trigger.throttleOutput,
+              triggerName: trigger.name,
             }),
           });
         } catch (error) {

--- a/src/subscribe.ts
+++ b/src/subscribe.ts
@@ -107,6 +107,7 @@ const runTask = async ({
           abortSignal: abortController?.signal,
           cwd: trigger.cwd,
           throttleOutput: trigger.throttleOutput,
+          triggerHexColor: trigger.hexColor,
           triggerName: trigger.name,
         }),
         taskId,
@@ -356,6 +357,7 @@ export const subscribe = (trigger: Trigger): Subscription => {
           await trigger.onTeardown({
             spawn: createSpawn(taskId, {
               throttleOutput: trigger.throttleOutput,
+              triggerHexColor: trigger.hexColor,
               triggerName: trigger.name,
             }),
           });

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,11 +100,13 @@ export type Throttle = {
  * @property interruptible Sends abort signal to an ongoing routine, if any. Otherwise, waits for routine to finish. (default: true)
  * @property initialRun Indicates whether onChange is run when the script is first initiated.
  * @property name Name of the trigger. Used for debugging. Must match /^[a-z0-9-_]+$/ pattern and must be unique.
+ * @property hexColor Hex color code used for logging.
  * @property onChange Routine that is executed when file changes are detected.
  * @property persistent Label a task as persistent if it is a long-running process, such as a dev server or --watch mode.
  */
 export type TriggerInput = {
   expression: Expression;
+  hexColor?: string;
   initialRun?: boolean;
   interruptible?: boolean;
   name: string;
@@ -119,6 +121,7 @@ export type Trigger = {
   abortSignal: AbortSignal;
   cwd?: string;
   expression: Expression;
+  hexColor?: string;
   id: string;
   initialRun: boolean;
   interruptible: boolean;

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -101,6 +101,7 @@ export const watch = (
         abortSignal,
         cwd,
         expression: trigger.expression,
+        hexColor: trigger.hexColor,
         id: generateShortId(),
         initialRun,
         interruptible: trigger.interruptible ?? true,


### PR DESCRIPTION
### Add Trigger Name Prefix and Customizable Hex Color to Logs for Enhanced Clarity and Consistency

### Description: 
This library has been a reliable tool in my workflow, especially in scenarios involving multiple server management. However, a notable limitation is the lack of trigger name prefixes in the logs. This omission complicates log analysis across different servers. To enhance usability, I suggest implementing a feature to prepend the trigger name to each log entry. Additionally, integrating the ability to specify a customizable hex color for each trigger's log output will further improve log clarity. This color consistency will aid in quickly identifying log entries related to specific triggers, making the debugging process more efficient in complex server environments.


### Screenshots 

**Before**
<img width="174" alt="image" src="https://github.com/gajus/turbowatch/assets/8260678/06d4004f-7a4a-4fe3-a553-05ff7011a27a">

**After**
<img width="342" alt="image" src="https://github.com/gajus/turbowatch/assets/8260678/d068775c-a0b4-4e58-a099-aad7eb5adb2e">


