### PR TITLE
docs: fix typo in default value for `initialRun`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ void watch({
         ]
       ],
       // Indicates whether the onChange routine should be triggered on script startup.
-      // Defaults to false. Set it to false if you would like onChange routine to not run until the first changes are detected.
+      // Defaults to true. Set it to false if you would like onChange routine to not run until the first changes are detected.
       initialRun: true,
       // Determines what to do if a new file change is detected while the trigger is executing.
       // If {interruptible: true}, then AbortSignal will abort the current onChange routine.


### PR DESCRIPTION
Based on the source code, `initialRun` is `true` by default.

https://github.com/gajus/turbowatch/blob/e233233240e14f79e6f3137da924d4939692e94d/src/watch.ts#L92